### PR TITLE
Fix monitor feed when there are namespaces 

### DIFF
--- a/resources/libraries/realtime.rb
+++ b/resources/libraries/realtime.rb
@@ -20,7 +20,8 @@ module Druid
           {"type" => "doubleMin", "fieldName" => "value", "name" => "min_value"}
         ]
         rb_monitor["feed"] = "rb_monitor"
-        rb_monitor["feed"] += "_post_"+namespace if !namespace.empty?
+        rb_monitor["feed"] += "_post" if namespaces.count > 1
+        rb_monitor["feed"] += "_"+namespace if !namespace.empty?
         rb_monitor_array.push(rb_monitor)
         }
 


### PR DESCRIPTION
in case there are namespaces the feed for `rb_monitor` should be `rb_monitor_post`, since in `rb_monitor` we have all the results (also from the namespaces)

```ruby
        rb_monitor_array = []
        namespaces.each { |namespace|
        rb_monitor={}
        rb_monitor["dataSource"] = "rb_monitor" 
        rb_monitor["dataSource"] += "_"+namespace if !namespace.empty?
        rb_monitor["dimensionExclusions"] = ["unit", "type", "value"]
        rb_monitor["metrics"] = [
          {"type" => "count", "name" => "events"},
          {"type" => "doubleSum", "fieldName" => "value", "name" => "sum_value"},
          {"type" => "doubleMax", "fieldName" => "value", "name" => "max_value"},
          {"type" => "doubleMin", "fieldName" => "value", "name" => "min_value"}
        ]
        rb_monitor["feed"] = "rb_monitor"    <=======
        rb_monitor["feed"] += "_post_"+namespace if !namespace.empty?
        rb_monitor_array.push(rb_monitor)
```