### PR TITLE
Configure druid service log rotation

### DIFF
--- a/resources/templates/default/log4j2.xml.erb
+++ b/resources/templates/default/log4j2.xml.erb
@@ -10,14 +10,20 @@
          </Policies>
          <DefaultRolloverStrategy max="5" />
       </RollingFile>
-        <File name="Druid" fileName="<%= "#{@log_dir}/#{@service_name}.log" %>">
-            <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
-        </File>
+      <RollingFile name="RollingDruid" fileName="<%= "#{@log_dir}/#{@service_name}.log" %>" filePattern="<%= "#{@log_dir}/#{@service_name}-%i.log" %>">
+          <PatternLayout>
+              <pattern>%d{ISO8601} %p [%t] %c - %m%n</pattern>
+          </PatternLayout>
+          <Policies>
+              <SizeBasedTriggeringPolicy size="10 MB" />
+          </Policies>
+          <DefaultRolloverStrategy max="5" />
+      </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="info">
-            <AppenderRef ref="Druid"/>
             <AppenderRef ref="RollingFile" />
+            <AppenderRef ref="RollingDruid"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
## Related issue in RedMine

- [[manager][druid] Configure druid service log rotation](https://redmine.redborder.lan/issues/17215) main task.

## Description / Motivation

The current configuration of the Druid services generates logs without any rotation limits creating a huge log file in terms of size.

## Detail

I modified `templates/default/log4j2.xml.erb` and created a log rotation and size limits for the `File` appender, modify it to a `RollingFile` appender, similar to the first appender. This allows specifying size limits and rollover strategies.

This will set a rotation of 5 files with a limitation of 10 MBs.