### PR TITLE
Bugfix/#18543 maxSize and segment max cache size is not pass (right now is using the default value) 

### DIFF
--- a/resources/providers/historical.rb
+++ b/resources/providers/historical.rb
@@ -26,6 +26,7 @@ action :add do
     memory_kb = new_resource.memory_kb
     rmi_address = new_resource.rmi_address
     rmi_port = new_resource.rmi_port
+    maxsize = new_resource.maxsize
 
     directory config_dir do
       owner 'root'
@@ -54,11 +55,8 @@ action :add do
     processing_threads = cpu_num > 1 ? cpu_num - 1 : 1 if processing_threads.nil?
     heap_historical_memory_kb, processing_memory_buffer_b = compute_memory(memory_kb, processing_threads)
     offheap_historical_memory_kb = (processing_memory_buffer_b * (processing_threads + 1) / 1024).to_i
-    free_memory_kb = heap_historical_memory_kb - offheap_historical_memory_kb - (1024 * 1024) # This is the overheap.
-    segments_memory_b = (free_memory_kb > 0 ? free_memory_kb : 0).to_i * 1024
-
-    max_size_b = 0
-    max_size_b = tier_memory_mode ? segments_memory_b : (disk_size_kb * 1024)
+    # free_memory_kb = heap_historical_memory_kb - offheap_historical_memory_kb - (1024 * 1024) # This is the overheap.
+    # segments_memory_b = (free_memory_kb > 0 ? free_memory_kb : 0).to_i * 1024
 
     Chef::Log.info(
       "\nHistorical Memory:
@@ -81,7 +79,7 @@ action :add do
       variables(name: name, cdomain: cdomain, port: port,
                 processing_threads: processing_threads, processing_memory_buffer_b: processing_memory_buffer_b,
                 groupby_max_intermediate_rows: groupby_max_intermediate_rows, groupby_max_results: groupby_max_results,
-                max_size_b: max_size_b, segment_cache_dir: segment_cache_dir)
+                maxsize: maxsize, segment_cache_dir: segment_cache_dir)
       notifies :restart, 'service[druid-historical]', :delayed
     end
 

--- a/resources/providers/historical.rb
+++ b/resources/providers/historical.rb
@@ -20,8 +20,6 @@ action :add do
     processing_threads = new_resource.processing_threads
     groupby_max_intermediate_rows = new_resource.groupby_max_intermediate_rows
     groupby_max_results = new_resource.groupby_max_results
-    disk_size_kb = new_resource.disk_size_kb
-    tier_memory_mode = new_resource.tier_memory_mode
     cpu_num = new_resource.cpu_num
     memory_kb = new_resource.memory_kb
     rmi_address = new_resource.rmi_address

--- a/resources/resources/historical.rb
+++ b/resources/resources/historical.rb
@@ -20,4 +20,4 @@ attribute :memory_kb, kind_of: Integer, default: 8388608
 attribute :rmi_address, kind_of: String, default: '127.0.0.1'
 attribute :rmi_port, kind_of: String, default: '9091'
 attribute :ipaddress, kind_of: String, default: '127.0.0.1'
-attribute :maxsize, kind_of: Integer, default: 10737418240
+attribute :maxsize, kind_of: Float, default: 10737418240.0

--- a/resources/resources/historical.rb
+++ b/resources/resources/historical.rb
@@ -22,3 +22,4 @@ attribute :disk_size_kb, kind_of: Integer, default: 10485760
 attribute :rmi_address, kind_of: String, default: '127.0.0.1'
 attribute :rmi_port, kind_of: String, default: '9091'
 attribute :ipaddress, kind_of: String, default: '127.0.0.1'
+attribute :maxsize, kind_of: Integer, default: 10737418240

--- a/resources/resources/historical.rb
+++ b/resources/resources/historical.rb
@@ -20,4 +20,4 @@ attribute :memory_kb, kind_of: Integer, default: 8388608
 attribute :rmi_address, kind_of: String, default: '127.0.0.1'
 attribute :rmi_port, kind_of: String, default: '9091'
 attribute :ipaddress, kind_of: String, default: '127.0.0.1'
-attribute :maxsize, kind_of: Float, default: 10737418240.0
+attribute :maxsize, kind_of: Integer, default: 10737418240

--- a/resources/resources/historical.rb
+++ b/resources/resources/historical.rb
@@ -15,10 +15,8 @@ attribute :segment_cache_dir, kind_of: String, default: '/var/druid/historical/i
 attribute :processing_threads, kind_of: Integer
 attribute :groupby_max_intermediate_rows, kind_of: Integer, default: 50000
 attribute :groupby_max_results, kind_of: Integer, default: 500000
-attribute :tier_memory_mode, kind_of: [TrueClass, FalseClass], default: false
 attribute :cpu_num, kind_of: Integer, default: 4
 attribute :memory_kb, kind_of: Integer, default: 8388608
-attribute :disk_size_kb, kind_of: Integer, default: 10485760
 attribute :rmi_address, kind_of: String, default: '127.0.0.1'
 attribute :rmi_port, kind_of: String, default: '9091'
 attribute :ipaddress, kind_of: String, default: '127.0.0.1'

--- a/resources/templates/default/historical.properties.erb
+++ b/resources/templates/default/historical.properties.erb
@@ -10,8 +10,8 @@ druid.server.tier=_default_tier
 <% end %>
 
 
-druid.server.maxSize=<%= @max_size_b  %>
-druid.segmentCache.locations=[{"path": "<%= @segment_cache_dir %>", "maxSize": <%= @max_size_b %>}]
+druid.server.maxSize=<%= @maxsize  %>
+druid.segmentCache.locations=[{"path": "<%= @segment_cache_dir %>", "maxSize": <%= @maxsize %>}]
 
 druid.historical.cache.useCache=true
 druid.historical.cache.populateCache=true


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/18543)

## Description

- Using `maxsize` variable passed from `harddisk_services` library method from `cookbook-rb-manager`.
- `disk_size_kb` and `tier_memory_mode` variabled were deleted because are not used anymore.
- Comenting variables that are not currently used.