### PR TITLE
add merge buffers and server priority

### DIFF
--- a/resources/providers/broker.rb
+++ b/resources/providers/broker.rb
@@ -50,8 +50,9 @@ action :add do
     http_num_connections = 20
 
     # Compute the heap memory, the processing buffer memory and the offheap memory
+    num_merge_buffers = [ processing_threads/4, 2 ].max.to_i
     heap_broker_memory_kb, processing_memory_buffer_b = compute_memory(memory_kb, processing_threads)
-    offheap_broker_memory_kb = (processing_memory_buffer_b * (processing_threads + 1) / 1024).to_i
+    offheap_broker_memory_kb = (processing_memory_buffer_b * (num_merge_buffers + processing_threads + 1) / 1024).to_i
 
     Chef::Log.info(
       "\nBroker Memory:

--- a/resources/providers/broker.rb
+++ b/resources/providers/broker.rb
@@ -50,7 +50,7 @@ action :add do
     http_num_connections = 20
 
     # Compute the heap memory, the processing buffer memory and the offheap memory
-    num_merge_buffers = [ processing_threads/4, 2 ].max.to_i
+    num_merge_buffers = [ processing_threads / 4, 2 ].max.to_i
     heap_broker_memory_kb, processing_memory_buffer_b = compute_memory(memory_kb, processing_threads)
     offheap_broker_memory_kb = (processing_memory_buffer_b * (num_merge_buffers + processing_threads + 1) / 1024).to_i
 

--- a/resources/providers/broker.rb
+++ b/resources/providers/broker.rb
@@ -73,7 +73,7 @@ action :add do
       mode '0644'
       retries 2
       variables(name: name, cdomain: cdomain, port: port,
-                processing_threads: processing_threads, http_num_connections: http_num_connections, http_num_threads: http_num_threads, processing_memory_buffer_b: processing_memory_buffer_b,
+                processing_threads: processing_threads, num_merge_buffers: num_merge_buffers, http_num_connections: http_num_connections, http_num_threads: http_num_threads, processing_memory_buffer_b: processing_memory_buffer_b,
                 groupby_max_intermediate_rows: groupby_max_intermediate_rows, groupby_max_results: groupby_max_results)
       notifies :restart, 'service[druid-broker]', :delayed
     end

--- a/resources/providers/historical.rb
+++ b/resources/providers/historical.rb
@@ -51,8 +51,9 @@ action :add do
 
     # Compute the number of processing threads based on CPUs
     processing_threads = cpu_num > 1 ? [ [cpu_num, 8].min.to_i, 1 ].max.to_i : 1 if processing_threads.nil?
+    num_merge_buffers = [ processing_threads/4, 2 ].max.to_i
     heap_historical_memory_kb, processing_memory_buffer_b = compute_memory(memory_kb, processing_threads)
-    offheap_historical_memory_kb = (processing_memory_buffer_b * (processing_threads + 1) / 1024).to_i
+    offheap_historical_memory_kb = (processing_memory_buffer_b * (num_merge_buffers + processing_threads + 1) / 1024).to_i
 
     Chef::Log.info(
       "\nHistorical Memory:

--- a/resources/providers/historical.rb
+++ b/resources/providers/historical.rb
@@ -51,7 +51,7 @@ action :add do
 
     # Compute the number of processing threads based on CPUs
     processing_threads = cpu_num > 1 ? [ [cpu_num, 8].min.to_i, 1 ].max.to_i : 1 if processing_threads.nil?
-    num_merge_buffers = [ processing_threads/4, 2 ].max.to_i
+    num_merge_buffers = [ processing_threads / 4, 2 ].max.to_i
     heap_historical_memory_kb, processing_memory_buffer_b = compute_memory(memory_kb, processing_threads)
     offheap_historical_memory_kb = (processing_memory_buffer_b * (num_merge_buffers + processing_threads + 1) / 1024).to_i
 

--- a/resources/providers/historical.rb
+++ b/resources/providers/historical.rb
@@ -74,7 +74,7 @@ action :add do
       mode '0644'
       retries 2
       variables(name: name, cdomain: cdomain, port: port,
-                processing_threads: processing_threads, processing_memory_buffer_b: processing_memory_buffer_b,
+                processing_threads: processing_threads, num_merge_buffers: num_merge_buffers, processing_memory_buffer_b: processing_memory_buffer_b,
                 groupby_max_intermediate_rows: groupby_max_intermediate_rows, groupby_max_results: groupby_max_results,
                 maxsize: maxsize, segment_cache_dir: segment_cache_dir)
       notifies :restart, 'service[druid-historical]', :delayed

--- a/resources/templates/default/broker.properties.erb
+++ b/resources/templates/default/broker.properties.erb
@@ -16,6 +16,7 @@ druid.monitoring.monitors=["io.druid.client.cache.CacheMonitor", "com.metamx.met
 
 # Processing
 druid.processing.numThreads=<%= @processing_threads %>
+druid.processing.numMergeBuffers=<%= @num_merge_buffers %>
 druid.processing.buffer.sizeBytes=<%= @processing_memory_buffer_b %>
 
 # Queries

--- a/resources/templates/default/historical.properties.erb
+++ b/resources/templates/default/historical.properties.erb
@@ -5,8 +5,10 @@ druid.port=<%= @port %>
 druid.server.http.numThreads=<%=([ node["cpu"]["total"].to_i-1, 1 ].max * 5)%>
 <% if !node["redborder"]["druid"].nil? and !node["redborder"]["druid"]["historical"].nil? and !node["redborder"]["druid"]["historical"]["tier"].nil? and node["redborder"]["druid"]["historical"]["tier"].class == String and node["redborder"]["druid"]["historical"]["tier"]!="default" %>
 druid.server.tier=<%= node["redborder"]["druid"]["historical"]["tier"] %>
+druid.server.priority=1
 <% else %>
 druid.server.tier=_default_tier
+druid.server.priority=0
 <% end %>
 
 
@@ -22,6 +24,7 @@ druid.monitoring.monitors=["io.druid.client.cache.CacheMonitor", "com.metamx.met
 
 # Processing
 druid.processing.numThreads=<%= @processing_threads %>
+druid.processing.numMergeBuffers=<%= @num_merge_buffers %>
 druid.processing.buffer.sizeBytes=<%= @processing_memory_buffer_b %>
 druid.query.groupBy.maxIntermediateRows=<%= @groupby_max_intermediate_rows %>
 druid.query.groupBy.maxResults=<%= @groupby_max_results %>


### PR DESCRIPTION
* Non-nested GroupBy queries require 1 merge buffer per query, while a nested GroupBy query requires 2 merge buffers (regardless of the depth of nesting). The number of merge buffers determines the number of GroupBy queries that can be processed concurrently
* If possible, indicate broker to always ask hot historical instead of default tier