### PR TITLE
BugFix #21087 Add extra memory to heap

### DIFF
--- a/resources/providers/historical.rb
+++ b/resources/providers/historical.rb
@@ -56,10 +56,10 @@ action :add do
     heap_historical_memory_kb, processing_memory_buffer_b = compute_memory(memory_kb, processing_threads)
     offheap_historical_memory_kb = (processing_memory_buffer_b * (num_merge_buffers + processing_threads + 1) / 1024).to_i
 
-    # Asign to the heap the memory we are not using
-    heap_historical_memory_kb_correction = memory_kb - offheap_historical_memory_kb
-    if heap_historical_memory_kb < heap_historical_memory_kb_correction
-      heap_historical_memory_kb = heap_historical_memory_kb_correction
+    # Ensure the heap memory value is at least as large as the calculated on-heap memory
+    onheap_memory_kb = memory_kb - offheap_historical_memory_kb
+    if heap_historical_memory_kb < onheap_memory_kb
+      heap_historical_memory_kb = onheap_memory_kb
     end
 
     Chef::Log.info(

--- a/resources/providers/historical.rb
+++ b/resources/providers/historical.rb
@@ -56,9 +56,9 @@ action :add do
     heap_historical_memory_kb, processing_memory_buffer_b = compute_memory(memory_kb, processing_threads)
     offheap_historical_memory_kb = (processing_memory_buffer_b * (num_merge_buffers + processing_threads + 1) / 1024).to_i
 
+    # Asign to the heap the memory we are not using
     heap_historical_memory_kb_correction = memory_kb - offheap_historical_memory_kb
     if heap_historical_memory_kb < heap_historical_memory_kb_correction
-      puts "Ajust heap of #{heap_historical_memory_kb / 1024} MB to #{heap_historical_memory_kb_correction / 1024} MB to take total possible memory (cgroup limit)"
       heap_historical_memory_kb = heap_historical_memory_kb_correction
     end
 

--- a/resources/providers/historical.rb
+++ b/resources/providers/historical.rb
@@ -56,6 +56,12 @@ action :add do
     heap_historical_memory_kb, processing_memory_buffer_b = compute_memory(memory_kb, processing_threads)
     offheap_historical_memory_kb = (processing_memory_buffer_b * (num_merge_buffers + processing_threads + 1) / 1024).to_i
 
+    heap_historical_memory_kb_correction = memory_kb - offheap_historical_memory_kb
+    if heap_historical_memory_kb < heap_historical_memory_kb_correction
+      puts "Ajust heap of #{heap_historical_memory_kb / 1024} MB to #{heap_historical_memory_kb_correction / 1024} MB to take total possible memory (cgroup limit)"
+      heap_historical_memory_kb = heap_historical_memory_kb_correction
+    end
+
     Chef::Log.info(
       "\nHistorical Memory:
         * Memory: #{memory_kb}k


### PR DESCRIPTION
Decided to fix this by assigning the remaining memory (calculated from the attribute values) to the heap.

I didn't modify the calculation of MaxDirectMemory or buffers—this change only increases the heap size if there's still unallocated memory available.